### PR TITLE
Implement phase 2 core collector

### DIFF
--- a/BatteryTracker.sln
+++ b/BatteryTracker.sln
@@ -10,6 +10,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BatteryTracker.Shared", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EtwEnergySpike", "prototypes\EtwEnergySpike\EtwEnergySpike.csproj", "{00CE7D7C-71D4-4AA5-9E1A-22D57BFB2057}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BatteryTracker.Cli", "src\BatteryTracker.Cli\BatteryTracker.Cli.csproj", "{C88AE886-631A-4F4F-B7FE-1A366EE0AC88}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BatteryTracker.Collector.Tests", "tests\BatteryTracker.Collector.Tests\BatteryTracker.Collector.Tests.csproj", "{FCFFDA26-88AE-4714-825B-D7CC74EC1A61}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -50,6 +54,22 @@ Global
         {00CE7D7C-71D4-4AA5-9E1A-22D57BFB2057}.Release|Any CPU.Build.0 = Release|Any CPU
         {00CE7D7C-71D4-4AA5-9E1A-22D57BFB2057}.Release|ARM64.ActiveCfg = Release|ARM64
         {00CE7D7C-71D4-4AA5-9E1A-22D57BFB2057}.Release|ARM64.Build.0 = Release|ARM64
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Debug|ARM64.ActiveCfg = Debug|ARM64
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Debug|ARM64.Build.0 = Debug|ARM64
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Release|Any CPU.Build.0 = Release|Any CPU
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Release|ARM64.ActiveCfg = Release|ARM64
+        {C88AE886-631A-4F4F-B7FE-1A366EE0AC88}.Release|ARM64.Build.0 = Release|ARM64
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Debug|ARM64.ActiveCfg = Debug|ARM64
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Debug|ARM64.Build.0 = Debug|ARM64
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Release|Any CPU.Build.0 = Release|Any CPU
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Release|ARM64.ActiveCfg = Release|ARM64
+        {FCFFDA26-88AE-4714-825B-D7CC74EC1A61}.Release|ARM64.Build.0 = Release|ARM64
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Battery Tracking is a Windows App SDK (WinUI 3) solution targeting Windows-on-AR
 BatteryTracker.sln
 ├── src/
 │   ├── BatteryTracker.App/               # WinUI 3 dashboard shell (net8.0-windows)
+│   ├── BatteryTracker.Cli/               # System.CommandLine host for start/stop/status control
 │   ├── BatteryTracker.Collector/         # Collector service primitives (sessions, storage, sensors)
 │   └── BatteryTracker.Shared/            # Cross-cutting models, configuration, telemetry contracts
+├── tests/
+│   └── BatteryTracker.Collector.Tests/   # Integration tests with mocked sensor adapters
 ├── prototypes/
 │   └── EtwEnergySpike/                   # TraceEvent spike that validates ETW energy providers
 └── docs/
@@ -23,6 +26,12 @@ BatteryTracker.sln
 - ✅ Established SQLite schema and ingestion pipeline for metrics and session metadata.
 - ✅ Added a WinUI 3 dashboard to exercise collector start/stop flows.
 - ✅ Captured findings, sampling policy, and open risks in `docs/inception/inception-summary.md`.
+
+## Phase 2 (Core collector) highlights
+
+- ✅ Introduced a `CpuPerformanceSensor` that samples Windows performance counters for utilization and frequency telemetry.
+- ✅ Delivered a verb-based CLI (`BatteryTracker.Cli`) that can start, stop, and inspect collector sessions from a terminal.
+- ✅ Added an integration test harness that validates session persistence with mocked sensor adapters.
 
 ## Getting started (Windows on ARM)
 
@@ -42,6 +51,21 @@ BatteryTracker.sln
    dotnet run --project prototypes/EtwEnergySpike/EtwEnergySpike.csproj
    ```
 
+## Command-line collector usage
+
+The CLI defaults to `%LOCALAPPDATA%\BatteryTracker` for data, logs, and session state. All commands accept `--data-directory` to override the location.
+
+```powershell
+# Start a new session, optionally attaching notes and an automatic stop timer.
+batterytracker start --notes "Perf sweep" --duration 00:10:00
+
+# Signal the currently running collector to flush and exit.
+batterytracker stop
+
+# Show whether the collector is running and summarize the most recent session.
+batterytracker status
+```
+
 ## Next steps
 
-Phase 2 (Core collector) will extend the collector with CPU/GPU adapters, integrate a verb-based CLI, and surface richer diagnostics through the UI.
+Phase 3 will focus on GPU/display/wireless adapters, richer diagnostics in the dashboard, and extending the reporting pipeline (PDF/visualizations).

--- a/src/BatteryTracker.Cli/BatteryTracker.Cli.csproj
+++ b/src/BatteryTracker.Cli/BatteryTracker.Cli.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RootNamespace>BatteryTracker.Cli</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BatteryTracker.Collector\BatteryTracker.Collector.csproj" />
+    <ProjectReference Include="..\BatteryTracker.Shared\BatteryTracker.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+</Project>

--- a/src/BatteryTracker.Cli/Program.cs
+++ b/src/BatteryTracker.Cli/Program.cs
@@ -1,0 +1,212 @@
+using System.CommandLine;
+using System.Security.Cryptography;
+using System.Text;
+using BatteryTracker.Collector.Sessions;
+
+var rootCommand = BuildRootCommand();
+return await rootCommand.InvokeAsync(args).ConfigureAwait(false);
+
+static RootCommand BuildRootCommand()
+{
+    var dataDirectoryOption = new Option<DirectoryInfo>(new[] { "--data-directory", "-d" },
+        () => new DirectoryInfo(GetDefaultDataDirectory()),
+        "Directory that stores the collector database, logs, and session metadata.");
+
+    var root = new RootCommand("Battery Tracker command-line interface for controlling the telemetry collector.");
+    root.AddGlobalOption(dataDirectoryOption);
+
+    var startCommand = new Command("start", "Start a telemetry session and continue running until stopped.");
+    var notesOption = new Option<string?>("--notes", description: "Optional notes to attach to the session record.");
+    var durationOption = new Option<TimeSpan?>("--duration", description: "Automatically stop after the specified duration (e.g. 00:15:00).");
+    startCommand.AddOption(notesOption);
+    startCommand.AddOption(durationOption);
+    startCommand.SetHandler(StartAsync, dataDirectoryOption, notesOption, durationOption);
+
+    var stopCommand = new Command("stop", "Signal the running telemetry session to stop.");
+    stopCommand.SetHandler(Stop, dataDirectoryOption);
+
+    var statusCommand = new Command("status", "Display the status of the collector and the most recent session.");
+    statusCommand.SetHandler(StatusAsync, dataDirectoryOption);
+
+    root.AddCommand(startCommand);
+    root.AddCommand(stopCommand);
+    root.AddCommand(statusCommand);
+    return root;
+}
+
+static async Task StartAsync(DirectoryInfo dataDirectory, string? notes, TimeSpan? duration)
+{
+    Directory.CreateDirectory(dataDirectory.FullName);
+    var stopSignalName = GetStopSignalName(dataDirectory.FullName);
+    using var stopSignal = new EventWaitHandle(false, EventResetMode.ManualReset, stopSignalName, out _);
+    stopSignal.Reset();
+
+    await using var host = CollectorHost.CreateDefault(dataDirectory.FullName);
+    var sessionStateStore = new SessionStateStore(dataDirectory.FullName);
+
+    using var cancellationSource = new CancellationTokenSource();
+    ConsoleCancelEventHandler? cancelHandler = null;
+    cancelHandler = (_, eventArgs) =>
+    {
+        eventArgs.Cancel = true;
+        if (!cancellationSource.IsCancellationRequested)
+        {
+            Console.WriteLine("Cancellation requested. Stopping telemetry session...");
+            cancellationSource.Cancel();
+        }
+    };
+    Console.CancelKeyPress += cancelHandler;
+
+    try
+    {
+        var session = await host.StartSessionAsync(notes, cancellationSource.Token).ConfigureAwait(false);
+        await sessionStateStore.WriteAsync(SessionStateSnapshot.FromMetadata(session), cancellationSource.Token).ConfigureAwait(false);
+
+        Console.WriteLine($"Started telemetry session {session.SessionId} at {session.StartedAt:G}.");
+        Console.WriteLine("Press Ctrl+C or run `batterytracker stop` to end the session.");
+        if (duration is { } positiveDuration && positiveDuration > TimeSpan.Zero)
+        {
+            Console.WriteLine($"The collector will automatically stop after {positiveDuration}.");
+        }
+
+        var waitForStopTask = WaitForStopSignalAsync(stopSignal, cancellationSource.Token);
+        Task? autoStopTask = null;
+        if (duration is { } timeout && timeout > TimeSpan.Zero)
+        {
+            autoStopTask = Task.Delay(timeout, cancellationSource.Token);
+        }
+
+        try
+        {
+            if (autoStopTask is null)
+            {
+                await waitForStopTask.ConfigureAwait(false);
+            }
+            else
+            {
+                var completed = await Task.WhenAny(waitForStopTask, autoStopTask).ConfigureAwait(false);
+                if (completed == autoStopTask)
+                {
+                    Console.WriteLine($"Elapsed {duration} — stopping session.");
+                    cancellationSource.Cancel();
+                }
+
+                await waitForStopTask.ConfigureAwait(false);
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Cancellation already handled by Ctrl+C handler logging above.
+        }
+
+        await host.StopSessionAsync().ConfigureAwait(false);
+        await sessionStateStore.WriteAsync(SessionStateSnapshot.FromMetadata(session), CancellationToken.None).ConfigureAwait(false);
+        stopSignal.Reset();
+        Console.WriteLine($"Session {session.SessionId} stopped at {session.CompletedAt:G}.");
+    }
+    catch (OperationCanceledException)
+    {
+        Console.WriteLine("Start cancelled before telemetry session could initialize.");
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to run telemetry session: {ex.Message}");
+    }
+    finally
+    {
+        Console.CancelKeyPress -= cancelHandler;
+    }
+}
+
+static void Stop(DirectoryInfo dataDirectory)
+{
+    var stopSignalName = GetStopSignalName(dataDirectory.FullName);
+    try
+    {
+        using var stopSignal = EventWaitHandle.OpenExisting(stopSignalName);
+        if (stopSignal.Set())
+        {
+            Console.WriteLine("Stop signal dispatched. Collector will flush and exit.");
+        }
+        else
+        {
+            Console.WriteLine("Stop signal was already set. Collector should stop shortly.");
+        }
+    }
+    catch (WaitHandleCannotBeOpenedException)
+    {
+        Console.WriteLine("No running telemetry session was found for the specified data directory.");
+    }
+    catch (UnauthorizedAccessException)
+    {
+        Console.Error.WriteLine("Access denied when signaling the collector. Ensure the process has sufficient privileges.");
+    }
+}
+
+static async Task StatusAsync(DirectoryInfo dataDirectory)
+{
+    var sessionStateStore = new SessionStateStore(dataDirectory.FullName);
+    try
+    {
+        var state = await sessionStateStore.ReadAsync().ConfigureAwait(false);
+        if (state is null)
+        {
+            Console.WriteLine("No telemetry sessions have been recorded yet.");
+            return;
+        }
+
+        if (state.IsActive)
+        {
+            Console.WriteLine($"Collector appears to be running. Session {state.SessionId} started at {state.StartedAt:G}.");
+        }
+        else
+        {
+            Console.WriteLine($"Collector is idle. Last session {state.SessionId} ran from {state.StartedAt:G} to {state.CompletedAt:G}.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(state.Notes))
+        {
+            Console.WriteLine($"Notes: {state.Notes}");
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Unable to read collector session state: {ex.Message}");
+    }
+}
+
+static async Task WaitForStopSignalAsync(EventWaitHandle stopSignal, CancellationToken cancellationToken)
+{
+    var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var registration = ThreadPool.RegisterWaitForSingleObject(stopSignal, static (state, _) =>
+    {
+        ((TaskCompletionSource<bool>)state!).TrySetResult(true);
+    }, completionSource, Timeout.Infinite, true);
+    using var cancellationRegistration = cancellationToken.Register(static state =>
+    {
+        ((TaskCompletionSource<bool>)state!).TrySetCanceled();
+    }, completionSource);
+
+    try
+    {
+        await completionSource.Task.ConfigureAwait(false);
+    }
+    finally
+    {
+        registration.Unregister(null);
+    }
+}
+
+static string GetDefaultDataDirectory()
+{
+    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BatteryTracker");
+}
+
+static string GetStopSignalName(string dataDirectory)
+{
+    var normalized = Path.GetFullPath(dataDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant();
+    using var sha256 = SHA256.Create();
+    var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(normalized));
+    var token = Convert.ToHexString(hash.AsSpan(0, 8));
+    return $"Local\\BatteryTracker.StopSignal.{token}";
+}

--- a/src/BatteryTracker.Cli/SessionStateSnapshot.cs
+++ b/src/BatteryTracker.Cli/SessionStateSnapshot.cs
@@ -1,0 +1,11 @@
+using BatteryTracker.Shared.Sessions;
+
+namespace BatteryTracker.Cli;
+
+internal sealed record SessionStateSnapshot(Guid SessionId, DateTimeOffset StartedAt, DateTimeOffset? CompletedAt, string? Notes)
+{
+    public bool IsActive => CompletedAt is null;
+
+    public static SessionStateSnapshot FromMetadata(SessionMetadata metadata)
+        => new(metadata.SessionId, metadata.StartedAt, metadata.CompletedAt, metadata.Notes);
+}

--- a/src/BatteryTracker.Cli/SessionStateStore.cs
+++ b/src/BatteryTracker.Cli/SessionStateStore.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace BatteryTracker.Cli;
+
+internal sealed class SessionStateStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly string _filePath;
+
+    public SessionStateStore(string dataDirectory)
+    {
+        Directory.CreateDirectory(dataDirectory);
+        _filePath = Path.Combine(dataDirectory, "session-state.json");
+    }
+
+    public async Task WriteAsync(SessionStateSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(snapshot, JsonOptions);
+        await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<SessionStateSnapshot?> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return null;
+        }
+
+        await using var stream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return await JsonSerializer.DeserializeAsync<SessionStateSnapshot>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
+++ b/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BatteryTracker.Collector/CollectorHost.cs
+++ b/src/BatteryTracker.Collector/CollectorHost.cs
@@ -47,6 +47,7 @@ public sealed class CollectorHost : IAsyncDisposable
         var adapters = new List<ISensorAdapter>
         {
             new AggregateBatterySensor(log),
+            new CpuPerformanceSensor(log),
         };
         var sessionManager = new CollectorSessionManager(samplingPolicy, pipeline, adapters, log);
         return new CollectorHost(storage, pipeline, sessionManager, log, ownsLogger ? log : logger as IDisposable);

--- a/src/BatteryTracker.Collector/Sensors/Cpu/CpuPerformanceSensor.cs
+++ b/src/BatteryTracker.Collector/Sensors/Cpu/CpuPerformanceSensor.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Channels;
+using BatteryTracker.Shared.Configuration;
+using BatteryTracker.Shared.Sessions;
+using BatteryTracker.Shared.Telemetry;
+using Serilog;
+
+namespace BatteryTracker.Collector.Sessions;
+
+/// <summary>
+/// Publishes CPU utilization and frequency metrics using Windows performance counters.
+/// </summary>
+public sealed class CpuPerformanceSensor : ISensorAdapter
+{
+    private readonly ILogger _logger;
+    private readonly HashSet<string> _loggedCounterFailures = new(StringComparer.OrdinalIgnoreCase);
+    private Channel<MetricSample> _channel = Channel.CreateUnbounded<MetricSample>();
+    private PeriodicTimer? _timer;
+    private CancellationTokenSource? _cts;
+    private PerformanceCounter? _utilizationCounter;
+    private PerformanceCounter? _performanceCounter;
+    private PerformanceCounter? _frequencyCounter;
+
+    public CpuPerformanceSensor(ILogger logger)
+    {
+        _logger = logger.ForContext<CpuPerformanceSensor>();
+    }
+
+    public Task StartAsync(SessionMetadata session, SamplingPolicy policy, CancellationToken cancellationToken)
+    {
+        _channel = Channel.CreateUnbounded<MetricSample>();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _timer = new PeriodicTimer(policy.HighPriorityInterval);
+
+        if (!TryInitializeCounters())
+        {
+            _logger.Warning("CPU performance counters are unavailable. No CPU samples will be produced during session {SessionId}.", session.SessionId);
+            _channel.Writer.TryComplete();
+            return Task.CompletedTask;
+        }
+
+        _ = Task.Run(() => PumpAsync(session.SessionId, _cts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync()
+    {
+        _cts?.Cancel();
+        if (_timer is not null)
+        {
+            await _timer.DisposeAsync().ConfigureAwait(false);
+            _timer = null;
+        }
+
+        _cts?.Dispose();
+        _cts = null;
+        DisposeCounters();
+        _channel.Writer.TryComplete();
+    }
+
+    public IAsyncEnumerable<MetricSample> ReadSamplesAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+
+    private async Task PumpAsync(Guid sessionId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (_timer is not null && await _timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var now = DateTimeOffset.UtcNow;
+                var samples = new List<MetricSample>(capacity: 3);
+
+                var utilization = ReadCounter(_utilizationCounter);
+                if (!double.IsNaN(utilization))
+                {
+                    samples.Add(new MetricSample(now, TelemetryComponent.Cpu, null, TelemetryMetric.UtilizationPercent, utilization, "%", "PDH"));
+                }
+
+                var performance = ReadCounter(_performanceCounter);
+                if (!double.IsNaN(performance))
+                {
+                    samples.Add(new MetricSample(now, TelemetryComponent.Cpu, "Performance", TelemetryMetric.UtilizationPercent, performance, "%", "PDH"));
+                }
+
+                var frequency = ReadCounter(_frequencyCounter);
+                if (!double.IsNaN(frequency))
+                {
+                    samples.Add(new MetricSample(now, TelemetryComponent.Cpu, null, TelemetryMetric.FrequencyMHz, frequency, "MHz", "PDH"));
+                }
+
+                foreach (var sample in samples)
+                {
+                    await _channel.Writer.WriteAsync(sample, cancellationToken).ConfigureAwait(false);
+                }
+
+                _logger.Verbose("Published {Count} CPU samples for session {SessionId} at {Timestamp}.", samples.Count, sessionId, now);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.Debug("CPU performance sensor pump cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Unexpected error while publishing CPU performance samples.");
+        }
+        finally
+        {
+            DisposeCounters();
+            _channel.Writer.TryComplete();
+        }
+    }
+
+    private bool TryInitializeCounters()
+    {
+        try
+        {
+            _utilizationCounter = new PerformanceCounter("Processor Information", "% Processor Utility", "_Total", readOnly: true);
+            _performanceCounter = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total", readOnly: true);
+            _frequencyCounter = new PerformanceCounter("Processor Information", "Processor Frequency", "_Total", readOnly: true);
+
+            _ = _utilizationCounter.NextValue();
+            _ = _performanceCounter.NextValue();
+            _ = _frequencyCounter.NextValue();
+            return true;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            _logger.Warning(ex, "Failed to initialize CPU performance counters.");
+            DisposeCounters();
+            return false;
+        }
+    }
+
+    private double ReadCounter(PerformanceCounter? counter)
+    {
+        if (counter is null)
+        {
+            return double.NaN;
+        }
+
+        try
+        {
+            var value = counter.NextValue();
+            return double.IsNaN(value) ? double.NaN : value;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            if (_loggedCounterFailures.Add(counter.CounterName))
+            {
+                _logger.Warning(ex, "CPU performance counter {Counter} is unavailable.", counter.CounterName);
+            }
+
+            return double.NaN;
+        }
+    }
+
+    private void DisposeCounters()
+    {
+        _utilizationCounter?.Dispose();
+        _performanceCounter?.Dispose();
+        _frequencyCounter?.Dispose();
+        _utilizationCounter = null;
+        _performanceCounter = null;
+        _frequencyCounter = null;
+    }
+}

--- a/tests/BatteryTracker.Collector.Tests/BatteryTracker.Collector.Tests.csproj
+++ b/tests/BatteryTracker.Collector.Tests/BatteryTracker.Collector.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BatteryTracker.Collector\BatteryTracker.Collector.csproj" />
+    <ProjectReference Include="..\..\src\BatteryTracker.Shared\BatteryTracker.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/BatteryTracker.Collector.Tests/CollectorSessionManagerTests.cs
+++ b/tests/BatteryTracker.Collector.Tests/CollectorSessionManagerTests.cs
@@ -1,0 +1,141 @@
+using System.Threading.Channels;
+using BatteryTracker.Collector.Sessions;
+using BatteryTracker.Shared.Configuration;
+using BatteryTracker.Shared.Sessions;
+using BatteryTracker.Shared.Telemetry;
+using Microsoft.Data.Sqlite;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace BatteryTracker.Collector.Tests;
+
+public sealed class CollectorSessionManagerTests
+{
+    [Fact]
+    public async Task StartAndStopSession_PersistsSamplesToStorage()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var databasePath = Path.Combine(tempDirectory, "collector-tests.db");
+
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(new NullSink())
+            .CreateLogger();
+
+        var storage = new Storage.StorageFacade(databasePath, batchSize: 16, logger);
+        var sessionId = Guid.Empty;
+        var expectedSamples = new[]
+        {
+            new MetricSample(DateTimeOffset.UtcNow, TelemetryComponent.System, null, TelemetryMetric.PowerMilliwatts, 1.5, "mW", "test"),
+            new MetricSample(DateTimeOffset.UtcNow, TelemetryComponent.System, null, TelemetryMetric.PowerMilliwatts, 2.5, "mW", "test"),
+            new MetricSample(DateTimeOffset.UtcNow, TelemetryComponent.System, null, TelemetryMetric.PowerMilliwatts, 3.5, "mW", "test"),
+        };
+
+        try
+        {
+            var pipeline = new TelemetryIngestionPipeline(storage, logger, capacity: 64);
+            var samplingPolicy = new SamplingPolicy
+            {
+                HighPriorityInterval = TimeSpan.FromMilliseconds(10),
+                MediumPriorityInterval = TimeSpan.FromMilliseconds(20),
+                LowPriorityInterval = TimeSpan.FromMilliseconds(30),
+            };
+
+            var sensor = new FakeSensorAdapter(expectedSamples);
+            var sessionManager = new CollectorSessionManager(samplingPolicy, pipeline, new[] { sensor }, logger);
+
+            var session = await sessionManager.StartAsync().ConfigureAwait(false);
+            sessionId = session.SessionId;
+
+            await Task.Delay(200).ConfigureAwait(false);
+
+            await sessionManager.StopAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await storage.DisposeAsync().ConfigureAwait(false);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath}");
+        connection.Open();
+
+        using (var metricsCommand = connection.CreateCommand())
+        {
+            metricsCommand.CommandText = "SELECT COUNT(*) FROM metrics WHERE session_id = $sessionId;";
+            metricsCommand.Parameters.AddWithValue("$sessionId", sessionId.ToString());
+            var count = Convert.ToInt32(metricsCommand.ExecuteScalar());
+            Assert.Equal(expectedSamples.Length, count);
+        }
+
+        using (var sessionCommand = connection.CreateCommand())
+        {
+            sessionCommand.CommandText = "SELECT end_time FROM sessions WHERE session_id = $sessionId;";
+            sessionCommand.Parameters.AddWithValue("$sessionId", sessionId.ToString());
+            var endTime = sessionCommand.ExecuteScalar() as string;
+            Assert.False(string.IsNullOrWhiteSpace(endTime));
+        }
+
+        Directory.Delete(tempDirectory, recursive: true);
+    }
+
+    private sealed class NullSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+
+    private sealed class FakeSensorAdapter : ISensorAdapter
+    {
+        private readonly IReadOnlyList<MetricSample> _samples;
+        private Channel<MetricSample> _channel = Channel.CreateUnbounded<MetricSample>();
+        private CancellationTokenSource? _cts;
+
+        public FakeSensorAdapter(IReadOnlyList<MetricSample> samples)
+        {
+            _samples = samples;
+        }
+
+        public Task StartAsync(SessionMetadata session, SamplingPolicy policy, CancellationToken cancellationToken)
+        {
+            _channel = Channel.CreateUnbounded<MetricSample>();
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var token = _cts.Token;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    foreach (var sample in _samples)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(5), token).ConfigureAwait(false);
+                        var emitted = sample with { Timestamp = DateTimeOffset.UtcNow };
+                        await _channel.Writer.WriteAsync(emitted, token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                finally
+                {
+                    _channel.Writer.TryComplete();
+                }
+            }, CancellationToken.None);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = null;
+            _channel.Writer.TryComplete();
+            return Task.CompletedTask;
+        }
+
+        public IAsyncEnumerable<MetricSample> ReadSamplesAsync(CancellationToken cancellationToken)
+            => _channel.Reader.ReadAllAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add a CPU performance counter–based sensor so the collector records utilization and frequency metrics
- introduce a System.CommandLine CLI host with start/stop/status verbs and persisted session state metadata
- add integration tests that exercise the collector pipeline with a mocked sensor and document the new workflow in the README

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c984dd9d2c8330abbc35e07c606169