### PR TITLE
Upgrade Windows target platform to 22621

### DIFF
--- a/src/BatteryTracker.App/BatteryTracker.App.csproj
+++ b/src/BatteryTracker.App/BatteryTracker.App.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240331000" />

--- a/src/BatteryTracker.Cli/BatteryTracker.Cli.csproj
+++ b/src/BatteryTracker.Cli/BatteryTracker.Cli.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>BatteryTracker.Cli</RootNamespace>
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BatteryTracker.Collector\BatteryTracker.Collector.csproj" />

--- a/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
+++ b/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>BatteryTracker.Collector</RootNamespace>
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BatteryTracker.Shared\BatteryTracker.Shared.csproj" />

--- a/src/BatteryTracker.Shared/BatteryTracker.Shared.csproj
+++ b/src/BatteryTracker.Shared/BatteryTracker.Shared.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/tests/BatteryTracker.Collector.Tests/BatteryTracker.Collector.Tests.csproj
+++ b/tests/BatteryTracker.Collector.Tests/BatteryTracker.Collector.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BatteryTracker.Collector\BatteryTracker.Collector.csproj" />


### PR DESCRIPTION
## Summary
- retarget all BatteryTracker projects to net8.0-windows10.0.22621.0
- declare SupportedOSPlatformVersion 10.0.22621.0 so the compiler knows Windows 11 APIs are required

## Testing
- dotnet build BatteryTracker.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a928a7c08330aea90415026bbceb