### PR TITLE
Switch to supported Windows SDK projections

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 </Project>

--- a/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
+++ b/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22621.756" />
+    <PackageReference Include="Microsoft.Windows.SDK.NET.Ref" Version="10.0.22621.2428" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />


### PR DESCRIPTION
## Summary
- replace the legacy Microsoft.Windows.SDK.Contracts package with the supported Microsoft.Windows.SDK.NET.Ref reference set
- enable Windows targeting globally so cross-compiling from non-Windows hosts continues to work

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9ae28e5888330912576225b12c4a0