### PR TITLE
Pin Windows SDK projection version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
+++ b/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22621.756" />
+    <PackageReference Include="Microsoft.Windows.SDK.NET.Ref" Version="[10.0.22621.2428]" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />


### PR DESCRIPTION
## Summary
- pin the Microsoft.Windows.SDK.NET.Ref dependency to the Windows 11 22H2 ref pack version so NuGet cannot float to the incompatible dotnetplatform build
- add a NuGet.config that ensures nuget.org is available when restoring to pull the pinned package

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9ae28e5888330912576225b12c4a0