### PR TITLE
Fix Windows SDK reference version

### DIFF
--- a/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
+++ b/src/BatteryTracker.Collector/BatteryTracker.Collector.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Windows.SDK.NET.Ref" Version="[10.0.22621.2428]" />
+    <PackageReference Include="Microsoft.Windows.SDK.NET.Ref" Version="10.0.22621.57" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />


### PR DESCRIPTION
## Summary
- update the Windows SDK reference to use a version available from NuGet so the CLI build can restore packages successfully

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9ccbf42d0833080e75ff166e525ae