### PR TITLE
Move MetricSummary to separate file

### DIFF
--- a/src/BatteryTracker.Cli/MetricSummary.cs
+++ b/src/BatteryTracker.Cli/MetricSummary.cs
@@ -1,0 +1,1 @@
+internal sealed record MetricSummary(string Component, string Metric, long Count, double Min, double Max, double Average);

--- a/src/BatteryTracker.Cli/Program.cs
+++ b/src/BatteryTracker.Cli/Program.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using BatteryTracker.Cli;
 using BatteryTracker.Collector.Sessions;
 using BatteryTracker.Shared.Sessions;
 using Microsoft.Data.Sqlite;
@@ -303,8 +304,6 @@ ORDER BY component, metric_type;";
 
     return summaries;
 }
-
-private sealed record MetricSummary(string Component, string Metric, long Count, double Min, double Max, double Average);
 
 static async Task WaitForStopSignalAsync(EventWaitHandle stopSignal, CancellationToken cancellationToken)
 {

--- a/src/BatteryTracker.Collector/CollectorHost.cs
+++ b/src/BatteryTracker.Collector/CollectorHost.cs
@@ -53,7 +53,8 @@ public sealed class CollectorHost : IAsyncDisposable
             new WirelessThroughputSensor(log),
         };
         var sessionManager = new CollectorSessionManager(samplingPolicy, pipeline, adapters, log);
-        return new CollectorHost(storage, pipeline, sessionManager, log, ownsLogger ? log : logger as IDisposable);
+        var loggerLifetime = ownsLogger ? log as IDisposable : logger as IDisposable;
+        return new CollectorHost(storage, pipeline, sessionManager, log, loggerLifetime);
     }
 
     public SessionMetadata? ActiveSession => _sessionManager.ActiveSession;


### PR DESCRIPTION
## Summary
- move the MetricSummary record into its own file so it no longer conflicts with the CLI's top-level statements
- import the CLI namespace within Program.cs so SessionStateStore and SessionStateSnapshot resolve correctly

## Testing
- :warning: `dotnet build BatteryTracker.sln` *(fails: `dotnet` command is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca30541a348330bea3ec2d893b7d87