### PR TITLE
Fix duplicate record definitions in CLI

### DIFF
--- a/src/BatteryTracker.Cli/PowerBreakdown.cs
+++ b/src/BatteryTracker.Cli/PowerBreakdown.cs
@@ -1,0 +1,13 @@
+namespace BatteryTracker.Cli;
+
+internal sealed record PowerBreakdown(
+    double SocTotalMilliwatts,
+    double? CpuMilliwatts,
+    double? GpuMilliwatts,
+    double? DisplayMilliwatts,
+    double? MotherboardMilliwatts)
+{
+    public static PowerBreakdown Empty { get; } = new(double.NaN, null, null, null, null);
+
+    public bool HasAnyData => !double.IsNaN(SocTotalMilliwatts);
+}

--- a/src/BatteryTracker.Cli/Program.cs
+++ b/src/BatteryTracker.Cli/Program.cs
@@ -451,16 +451,3 @@ static string GetStopSignalName(string dataDirectory)
     return $"Local\\BatteryTracker.StopSignal.{token}";
 }
 
-private sealed record MetricSummary(string Component, string Metric, long Count, double Min, double Max, double Average);
-
-private sealed record PowerBreakdown(
-    double SocTotalMilliwatts,
-    double? CpuMilliwatts,
-    double? GpuMilliwatts,
-    double? DisplayMilliwatts,
-    double? MotherboardMilliwatts)
-{
-    public static PowerBreakdown Empty { get; } = new(double.NaN, null, null, null, null);
-
-    public bool HasAnyData => !double.IsNaN(SocTotalMilliwatts);
-}


### PR DESCRIPTION
## Summary
- remove redundant MetricSummary record declaration from Program.cs to avoid duplicate type definitions
- move PowerBreakdown record into a dedicated file with internal visibility so it can be referenced across the CLI

## Testing
- dotnet build BatteryTracker.sln *(fails: dotnet executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab813274483308dc3496c9e6f5a84